### PR TITLE
Build for Python 3.11

### DIFF
--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -17,7 +17,7 @@ jobs:
     name: ${{ matrix.name }}
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         include:
           - name: MacOS ARM
             os: macos-latest
@@ -113,7 +113,7 @@ jobs:
     name: ${{ matrix.name }}
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         include:
           - name: Linux x86
             os: ubuntu-latest
@@ -262,7 +262,7 @@ jobs:
     name: ${{ matrix.name }}
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         include:
           - name: Windows x86
             os: windows-latest


### PR DESCRIPTION
Since it seems there's no way to replace the 3.10 builds on the test server. :(

cc @mikemhenry